### PR TITLE
Процесс завершения оплаты в модуле ya_ubercart приведен в соответстви…

### DIFF
--- a/ya_ubercart/ya_ubercart.module
+++ b/ya_ubercart/ya_ubercart.module
@@ -147,9 +147,9 @@ function ya_ubercart_yamoney_process_payment_alter(&$payment) {
   $order = uc_order_load($transaction->order_id);
   if ($order) {
     //print_r($order);
+    uc_payment_enter($order->order_id, 'ya_ubercart', $transaction->amount, $order->uid, NULL, t('Yandex.Money transaction ID: @txn_id', array('@txn_id' => $transaction->ymid)));
     uc_cart_complete_sale($order);
     uc_cart_empty($order->uid);
-    uc_order_update_status($order->order_id, 'payment_received');
     $payment['success'] = TRUE;
   }
   else {


### PR DESCRIPTION
Процесс завершения оплаты для модуля **ya_ubercart** приведен в соответствие с логикой работы платежных модулей для Ubercart - в функции **ya_ubercart_yamoney_process_payment_alter** (имплементация хука **hook_yamoney_process_payment_alter**) убран вызов функции **uc_order_update_status**, вместо него добавлен вызов функции **uc_payment_enter**).